### PR TITLE
remove System.Drawing and replace with SkiaSharp

### DIFF
--- a/GameBoyPngConverter/GameBoyPngConverter.csproj
+++ b/GameBoyPngConverter/GameBoyPngConverter.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64;</RuntimeIdentifiers>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <AssemblyVersion>2.1.0</AssemblyVersion>
     <FileVersion></FileVersion>
-    <Version>$(VersionPrefix)2.0.0</Version>
+    <Version>$(VersionPrefix)2.1.0</Version>
+    <PublishTrimmed>false</PublishTrimmed>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +23,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed the dependency on System.Drawing as it is now attributed as Windows-only (https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only) and replaced it with SkiaSharp as proposed by Microsoft.

This should fix issue #8 as it is no longer dependent on System.Drawing.

Updated to .NET 8.0 as 6.0 is no longer supported.